### PR TITLE
Remove console.log

### DIFF
--- a/lib/SPFValidator.js
+++ b/lib/SPFValidator.js
@@ -216,7 +216,6 @@ class SPFValidator {
       case 'ip6':
         return this.validateIp(mechanism, sender);
       default:
-        console.log(mechanism);
         return NEUTRAL;
     }
   }


### PR DESCRIPTION
Until other mechanisms are implemented, remove `console.log`.

Fixes #1.